### PR TITLE
dir2pi should generate an index.html file in the package dir

### DIFF
--- a/libpip2pi/commands.py
+++ b/libpip2pi/commands.py
@@ -86,7 +86,7 @@ def dir2pi(argv=sys.argv):
         symlink_source = os.path.join("../../", pkg_basename)
         os.symlink(symlink_source, symlink_target)
         fp = open(os.path.join(pkg_dir, 'index.html'), 'a')
-        fp.write('<a href="%s">%s</a>\n' % (pkg_new_basename, pkg_name))
+        fp.write("<a href=\"%s\">%s</a>\n" % (pkg_new_basename, pkg_new_basename))
         fp.close()
 
 


### PR DESCRIPTION
Using a repository generated by dir2pi failed on a machine with pip-1.3.1 installed. I did not track the exact pip change that caused this but looks like the index.html file is required now.
