### PR TITLE
Normalize simple/package directories

### DIFF
--- a/libpip2pi/commands.py
+++ b/libpip2pi/commands.py
@@ -291,7 +291,7 @@ def _dir2pi(option, argv):
 
         pkg_dir_name = pkg_name
         if option.normalize_package_names:
-            pkg_dir_name = pkg_dir_name.lower()
+            pkg_dir_name = pkg_dir_name.lower().replace(".", "-")
         elif pkg_dir_name != pkg_dir_name.lower():
             if option.normalize_package_names is None:
                 warn_normalized_pkg_names.append(pkg_name)


### PR DESCRIPTION

Why:

* When installing something like dogpile.cache or backports.shutil-get-terminal-size pip looks in directories like simple/dogpile-cache/ or simple/backports-shutil-get-terminal-size/

This change addresses the need by:

* https://github.com/wolever/pip2pi/issues/55