### PR TITLE
Maintain generated filename for wheels to avoid conflicting symlinks.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ env:
   - TOX_ENV=py27
   - TOX_ENV=pypy
 install:
-  - pip install --use-mirrors tox==1.6.1
+  - pip install tox==1.6.1
 script:
   - tox -e $TOX_ENV

--- a/libpip2pi/commands.py
+++ b/libpip2pi/commands.py
@@ -94,7 +94,7 @@ def file_to_package(file, basedir=None):
         >>> file_to_package("python_ldap-2.3.9-py2.7-macosx-10.3-fat.egg")
         ('python-ldap', '2.3.9-py2.7-macosx-10.3-fat.egg')
         >>> file_to_package("python_ldap-2.4.19-cp27-none-macosx_10_10_x86_64.whl")
-        ('python-ldap', '2.4.19-cp27-none-macosx_10_10_x86_64.whl')
+        ('python_ldap', '2.4.19-cp27-none-macosx_10_10_x86_64.whl')
         >>> file_to_package("foo.whl")
         Traceback (most recent call last):
             ...

--- a/libpip2pi/commands.py
+++ b/libpip2pi/commands.py
@@ -115,7 +115,7 @@ def file_to_package(file, basedir=None):
     elif file_ext == ".whl":
         bits = file.rsplit("-", 4)
         split = (bits[0], "-".join(bits[1:]))
-        to_safe_name = pkg_resources.safe_name
+        to_safe_name = lambda x: x
         to_safe_rest = lambda x: x
     else:
         match = re.search(r"(?P<pkg>.*?)-(?P<rest>\d+.*)", file)
@@ -291,7 +291,7 @@ def _dir2pi(option, argv):
 
         pkg_dir_name = pkg_name
         if option.normalize_package_names:
-            pkg_dir_name = pkg_dir_name.lower()
+            pkg_dir_name = pkg_dir_name.lower().replace('_','-')
         elif pkg_dir_name != pkg_dir_name.lower():
             if option.normalize_package_names is None:
                 warn_normalized_pkg_names.append(pkg_name)

--- a/libpip2pi/commands.py
+++ b/libpip2pi/commands.py
@@ -291,7 +291,7 @@ def _dir2pi(option, argv):
 
         pkg_dir_name = pkg_name
         if option.normalize_package_names:
-            pkg_dir_name = pkg_dir_name.lower().replace('_','-')
+            pkg_dir_name = pkg_dir_name.lower().replace('_', '-').replace('.', '-')
         elif pkg_dir_name != pkg_dir_name.lower():
             if option.normalize_package_names is None:
                 warn_normalized_pkg_names.append(pkg_name)


### PR DESCRIPTION
As noted in [this issue](https://github.com/wolever/pip2pi/issues/50), pip2pi's normalized filenames cause symbolic link conflicts with the filename generated by `pip wheel`. The `dir2pi` command throws an exception when both files are present. 

This change makes it so that dir2pi uses the filename generated by `pip wheel`, while still normalizing the package's directory name. This way it is less likely to find yourself in a situation where you have both files.

Before:
```
$ rm -rf packages/simple/* \
    && dir2pi -n packages/ \
    && ll packages/simple/mysql-python/ \
    && pip install --no-index --find-links=file:///tmp/pip2pi/packages/ mysql-python && pip uninstall -y mysql-python
total 24
lrwxr-xr-x  1 hoglund  wheel    60B Sep 11 14:53 MySQL-python-1.2.3-cp27-cp27mu-macosx_10_11_x86_64.whl -> ../../MySQL_python-1.2.3-cp27-cp27mu-macosx_10_11_x86_64.whl
lrwxr-xr-x  1 hoglund  wheel    60B Sep 11 14:53 MySQL-python-1.2.5-cp27-cp27mu-macosx_10_11_x86_64.whl -> ../../MySQL_python-1.2.5-cp27-cp27mu-macosx_10_11_x86_64.whl
-rw-r--r--  1 hoglund  wheel   260B Sep 11 14:53 index.html
Ignoring indexes: https://pypi.python.org/simple
Collecting mysql-python
Installing collected packages: mysql-python
Successfully installed mysql-python-1.2.5
Uninstalling MySQL-python-1.2.5:
  Successfully uninstalled MySQL-python-1.2.5
```

After:
```
$ rm -rf packages/simple/* \
    && dir2pi -n packages/ \
    && ll packages/simple/mysql-python/ \
    && pip install --no-index --find-links=file:///tmp/pip2pi/packages/ mysql-python && pip uninstall -y mysql-python
total 24
lrwxr-xr-x  1 hoglund  wheel    60B Sep 11 14:51 MySQL_python-1.2.3-cp27-cp27mu-macosx_10_11_x86_64.whl -> ../../MySQL_python-1.2.3-cp27-cp27mu-macosx_10_11_x86_64.whl
lrwxr-xr-x  1 hoglund  wheel    60B Sep 11 14:51 MySQL_python-1.2.5-cp27-cp27mu-macosx_10_11_x86_64.whl -> ../../MySQL_python-1.2.5-cp27-cp27mu-macosx_10_11_x86_64.whl
-rw-r--r--  1 hoglund  wheel   260B Sep 11 14:51 index.html
Ignoring indexes: https://pypi.python.org/simple
Collecting mysql-python
Installing collected packages: mysql-python
Successfully installed mysql-python-1.2.5
Uninstalling MySQL-python-1.2.5:
  Successfully uninstalled MySQL-python-1.2.5
```