### PR TITLE
Add option to build wheels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ tags
 
 # ETags
 TAGS
+
+# pyenv
+.python-version

--- a/libpip2pi/commands.py
+++ b/libpip2pi/commands.py
@@ -387,7 +387,7 @@ def pip2tgz(argv=sys.argv):
         description=dedent("""
             Where PACKAGES are any names accepted by pip (ex, `foo`,
             `foo==1.2`, `-r requirements.txt`), and [PIP_OPTIONS] can be any
-            options accepted by `pip download -d`.
+            options accepted by `pip install -d`.
 
             pip2tgz will download all packages required to install PACKAGES and
             save them to sanely-named tarballs or wheel files in OUTPUT_DIRECTORY.
@@ -422,9 +422,9 @@ def pip2tgz(argv=sys.argv):
         pip_run_command(['wheel', '--wheel-dir', outdir] + argv[2:])
     # download source tarballs only
     if option.get_source:
-        pip_run_command(['download', '-d', outdir, '--no-binary', ':all:'] + argv[2:])
+        pip_run_command(['install', '-d', outdir, '--no-use-wheel'] + argv[2:])
     # let index decide what to download
-    pip_run_command(['download', '-d', outdir] + argv[2:])
+    pip_run_command(['install', '-d', outdir] + argv[2:])
 
     os.chdir(outdir)
     new_pkgs = pkg_file_set() - old_pkgs
@@ -499,7 +499,7 @@ def pip2pi(argv=sys.argv):
             package index will be built locally and rsync will be used to copy
             it to the remote host.
 
-            PIP_OPTIONS can be any options accepted by `pip download -d`, like
+            PIP_OPTIONS can be any options accepted by `pip install -d`, like
             `--index-url` or `--no-use-wheel`.
 
             For example, to create a remote index:

--- a/libpip2pi/commands.py
+++ b/libpip2pi/commands.py
@@ -212,6 +212,7 @@ class Pip2PiOptionParser(optparse.OptionParser):
             '-v', '--verbose', dest="verbose", action="store_true")
 
     def add_wheel_index_options(self):
+        ''' Options related to downloading and building wheels '''
         self.add_option(
             '-z', '--also-get-source', dest="get_source", action="store_true",
             default=False, help=dedent("""
@@ -416,10 +417,13 @@ def pip2tgz(argv=sys.argv):
     pkg_file_set = lambda: set(globall(full_glob_paths))
     old_pkgs = pkg_file_set()
 
+    # download/compile wheels only
     if option.build_wheels:
         pip_run_command(['wheel', '--wheel-dir', outdir] + argv[2:])
+    # download source tarballs only
     if option.get_source:
         pip_run_command(['download', '-d', outdir, '--no-binary', ':all:'] + argv[2:])
+    # let index decide what to download
     pip_run_command(['download', '-d', outdir] + argv[2:])
 
     os.chdir(outdir)

--- a/libpip2pi/commands.py
+++ b/libpip2pi/commands.py
@@ -220,8 +220,8 @@ class Pip2PiOptionParser(optparse.OptionParser):
                 platform using this index does not support the wheel/egg/etc
             """))
         self.add_option(
-            '-w', '--wheel', action='store_true',
-            help='Download and build wheels only with the `pip wheel` command.')
+            '-w', '--build-wheels', action='store_true',
+            help='Build wheels from source packages with `pip wheel`.')
 
     def _process_args(self, largs, rargs, values):
         """
@@ -416,7 +416,7 @@ def pip2tgz(argv=sys.argv):
     pkg_file_set = lambda: set(globall(full_glob_paths))
     old_pkgs = pkg_file_set()
 
-    if option.wheel:
+    if option.build_wheels:
         pip_run_command(['wheel', '--wheel-dir', outdir] + argv[2:])
     if option.get_source:
         pip_run_command(['download', '-d', outdir, '--no-binary', ':all:'] + argv[2:])

--- a/tests/test.py
+++ b/tests/test.py
@@ -198,7 +198,7 @@ class Pip2PiHeavyTests(unittest.TestCase):
 
     def exc(self, cmd, args):
         print("Running %s with: %s" %(cmd, args))
-        return getattr(pip2pi_commands, cmd)([cmd] + args)
+        return getattr(pip2pi_commands, cmd)(argv=[cmd] + args)
 
     def test_requirements_txt(self):
         res = self.exc("pip2pi", [

--- a/tests/test.py
+++ b/tests/test.py
@@ -243,6 +243,11 @@ class Pip2PiHeavyTests(unittest.TestCase):
         self.assertEqual(res, 0)
         self.assertDirContents('expected-test_get_source_with_wheels.txt', self.temp_dir)
 
+    def test_building_wheels_only(self):
+        res = self.exc('pip2tgz', [self.temp_dir, self.index_url, '--wheel', 'fish'])
+        self.assertEqual(res, 0)
+        self.assertIn('fish-1.1-py2-none-any.whl', os.listdir(self.temp_dir))
+
 
 class TestIsRemoteTarget(unittest.TestCase):
     remote_targets = [

--- a/tests/test.py
+++ b/tests/test.py
@@ -250,7 +250,7 @@ class Pip2PiHeavyTests(unittest.TestCase):
         )
         self.assertEqual(res, 0)
         artifacts = os.listdir(self.temp_dir)
-        self.assertIn('fish-1.1-py2-none-any.whl', artifacts)
+        self.assertIn('fish-1.1-py{}-none-any.whl'.format(sys.version_info.major), artifacts)
         self.assertIn('fish-1.1.tar.gz', artifacts)
 
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -246,10 +246,9 @@ class Pip2PiHeavyTests(unittest.TestCase):
     def test_building_wheels(self):
         res = self.exc(
             'pip2tgz',
-            [self.temp_dir, self.index_url, '--wheel', '--also-get-source', 'fish']
+            [self.temp_dir, self.index_url, '--build-wheels', '--also-get-source', 'fish']
         )
         self.assertEqual(res, 0)
-        print os.listdir(self.temp_dir)
         artifacts = os.listdir(self.temp_dir)
         self.assertIn('fish-1.1-py2-none-any.whl', artifacts)
         self.assertIn('fish-1.1.tar.gz', artifacts)

--- a/tests/test.py
+++ b/tests/test.py
@@ -243,10 +243,16 @@ class Pip2PiHeavyTests(unittest.TestCase):
         self.assertEqual(res, 0)
         self.assertDirContents('expected-test_get_source_with_wheels.txt', self.temp_dir)
 
-    def test_building_wheels_only(self):
-        res = self.exc('pip2tgz', [self.temp_dir, self.index_url, '--wheel', 'fish'])
+    def test_building_wheels(self):
+        res = self.exc(
+            'pip2tgz',
+            [self.temp_dir, self.index_url, '--wheel', '--also-get-source', 'fish']
+        )
         self.assertEqual(res, 0)
-        self.assertIn('fish-1.1-py2-none-any.whl', os.listdir(self.temp_dir))
+        print os.listdir(self.temp_dir)
+        artifacts = os.listdir(self.temp_dir)
+        self.assertIn('fish-1.1-py2-none-any.whl', artifacts)
+        self.assertIn('fish-1.1.tar.gz', artifacts)
 
 
 class TestIsRemoteTarget(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,35}-pip{6,7,8}
+envlist = py{27,35}-pip{6,7,8,9}
 
 [testenv]
 deps =


### PR DESCRIPTION
Related to issue https://github.com/wolever/pip2pi/issues/40

Changes:
- Added the `--build-wheels` option to `pip2tgz` and `pip2pi`, which simply runs `pip wheel` on the passed in packages
- Adding pip9 test environment