### PR TITLE
Fixes the deprecation warning

### DIFF
--- a/libpip2pi/commands.py
+++ b/libpip2pi/commands.py
@@ -410,7 +410,7 @@ def pip2tgz(argv=sys.argv):
     pkg_file_set = lambda: set(globall(full_glob_paths))
     old_pkgs = pkg_file_set()
 
-    pip_run_command(['install', '-d', outdir] + argv[2:])
+    pip_run_command(['download', '-d', outdir] + argv[2:])
 
     os.chdir(outdir)
     new_pkgs = pkg_file_set() - old_pkgs


### PR DESCRIPTION
Fixes the warning: 
DEPRECATION: pip install --download has been deprecated  and will be removed in
the future. Pip now has a download command that should be used instead.

<img width="1063" alt="screen shot 2017-06-01 at 09 10 49" src="https://cloud.githubusercontent.com/assets/833219/26663724/4c8c7c08-46aa-11e7-9cb9-8bcc1d051d48.png">


Uses the new `pip download` command instead of the deprecated `pip install`.