### PR TITLE
Changed dir2pi to use original file name in file link.

### DIFF
--- a/libpip2pi/commands.py
+++ b/libpip2pi/commands.py
@@ -363,8 +363,7 @@ def _dir2pi(option, argv):
             try_symlink(option, pkg_dir_name, pkgdirpath("simple", normalize_pip67(pkg_name)))
             try_symlink(option, pkg_dir_name, pkgdirpath("simple", pkg_name))
 
-        pkg_new_basename = "-".join([pkg_name, pkg_rest])
-        symlink_target = os.path.join(pkg_dir, pkg_new_basename)
+        symlink_target = os.path.join(pkg_dir, pkg_basename)
         symlink_source = os.path.join("../../", pkg_basename)
         if option.use_symlink:
             try_symlink(option, symlink_source, symlink_target)
@@ -383,7 +382,7 @@ def _dir2pi(option, argv):
         if option.build_html:
             with open(os.path.join(pkg_dir, "index.html"), "a") as fp:
                 fp.write("<a href='%(name)s'>%(name)s</a><br />\n" %{
-                    "name": cgi.escape(pkg_new_basename),
+                    "name": cgi.escape(pkg_basename),
                 })
     pkg_index += "</body></html>\n"
 

--- a/tests/test_requirements_txt/expected-aggressively-normalized.txt
+++ b/tests/test_requirements_txt/expected-aggressively-normalized.txt
@@ -8,5 +8,5 @@ simple/fish/index.html
 simple/index.html
 simple/normalization-test-with-dashes
 simple/normalization-test-with-dashes/index.html
-simple/normalization-test-with-dashes/Normalization-Test.with-dashes-1.2rc3.zip -> ../../Normalization_Test.with-dashes-1.2rc3.zip
+simple/normalization-test-with-dashes/Normalization_Test.with-dashes-1.2rc3.zip -> ../../Normalization_Test.with-dashes-1.2rc3.zip
 simple/normalization-test.with-dashes -> normalization-test-with-dashes

--- a/tests/test_requirements_txt/expected-normal.txt
+++ b/tests/test_requirements_txt/expected-normal.txt
@@ -7,4 +7,4 @@ simple/fish/index.html
 simple/index.html
 simple/normalization-test-with-dashes
 simple/normalization-test-with-dashes/index.html
-simple/normalization-test-with-dashes/Normalization-Test.with-dashes-1.2rc3.zip -> ../../Normalization_Test.with-dashes-1.2rc3.zip
+simple/normalization-test-with-dashes/Normalization_Test.with-dashes-1.2rc3.zip -> ../../Normalization_Test.with-dashes-1.2rc3.zip


### PR DESCRIPTION
As pkg_new_basename was constructed from the normalized package name, it did not always match the original filename. This caused problems with wheels with underscores. Now the original filename (pkg_basename) is used in file link, so the link should match exactly. 

I think this change should fix https://github.com/wolever/pip2pi/issues/76 and https://github.com/wolever/pip2pi/issues/84, and is alternative to https://github.com/wolever/pip2pi/pull/67.

I updated also test cases to match this change.