### PR TITLE
fix use html.escape instead of cgi.escape

### DIFF
--- a/libpip2pi/commands.py
+++ b/libpip2pi/commands.py
@@ -19,6 +19,11 @@ try:
 except ImportError:
     has_wheel = False
 
+try:
+    import html
+    cgi.escape = html.escape
+except ImportError:
+    pass
 
 def try_int(x):
     try:


### PR DESCRIPTION
python 3.8+ remove cgi.escape, use html.escape to support python 3.8+