### PR TITLE
Changed cgi.escape to html.escape

### DIFF
--- a/libpip2pi/commands.py
+++ b/libpip2pi/commands.py
@@ -11,7 +11,11 @@ from subprocess import check_call
 import pkg_resources
 import glob
 import optparse
-from html import escape
+
+try:
+    from html import escape
+except ImportError:
+    from cgi import escape
 
 try:
     import wheel as _; _

--- a/libpip2pi/commands.py
+++ b/libpip2pi/commands.py
@@ -1,7 +1,6 @@
 import os
 import re
 import sys
-import cgi
 import shutil
 import atexit
 import tempfile
@@ -12,6 +11,7 @@ from subprocess import check_call
 import pkg_resources
 import glob
 import optparse
+from html import escape
 
 try:
     import wheel as _; _
@@ -374,15 +374,15 @@ def _dir2pi(option, argv):
 
         if pkg_name not in processed_pkg:
             pkg_index += "<a href='%s/'>%s</a><br />\n" %(
-                cgi.escape(pkg_dir_name),
-                cgi.escape(pkg_name),
+                escape(pkg_dir_name),
+                escape(pkg_name),
             )
             processed_pkg.add(pkg_name)
 
         if option.build_html:
             with open(os.path.join(pkg_dir, "index.html"), "a") as fp:
                 fp.write("<a href='%(name)s'>%(name)s</a><br />\n" %{
-                    "name": cgi.escape(pkg_basename),
+                    "name": escape(pkg_basename),
                 })
     pkg_index += "</body></html>\n"
 


### PR DESCRIPTION
Hi all,

This PR closes #96 by changing `cgi.escape` to `html.escape`. As @wtnb75 said, `cgi.escape` is deprecated since Python 3.2 and the last version to support this was Python 3.7.x. Here you can read more about this: https://docs.python.org/3.7/library/cgi.html#cgi.escape.

Regards.