### PR TITLE
Add --exlcude option

### DIFF
--- a/libpip2pi/commands.py
+++ b/libpip2pi/commands.py
@@ -2,6 +2,7 @@ import os
 import re
 import sys
 import shutil
+import fnmatch
 import atexit
 import tempfile
 import warnings
@@ -230,6 +231,11 @@ class Pip2PiOptionParser(optparse.OptionParser):
                 package/module versions continue to be available.
             """))
         self.add_option(
+            '-X', '--exclude', dest="exclude", metavar="SHELLGLOB",
+            help=dedent("""
+                Exclude files in PACKAGE_DIR whose basename matches SHELLGLOB.
+            """))
+        self.add_option(
             '-z', '--also-get-source', dest="get_source", action="store_true",
             default=False, help=dedent("""
                 In addition to downloading wheels, eggs or any other package
@@ -352,6 +358,8 @@ def _dir2pi(option, argv):
             continue
         pkg_basename = os.path.basename(file)
         if pkg_basename.startswith("."):
+            continue
+        if option.exclude and fnmatch.fnmatchcase(pkg_basename, option.exclude):
             continue
         pkg_name, pkg_rest = file_to_package(pkg_basename, pkgdir)
 


### PR DESCRIPTION
I happen to have an `index.html` in my PACKAGE_DIR and get the following
```console
user@host$ dir2pi .
Traceback (most recent call last):
  File "/opt/homebrew/bin/dir2pi", line 8, in <module>
    sys.exit(dir2pi())
  File "/opt/homebrew/lib/python3.8/site-packages/libpip2pi/commands.py", line 312, in dir2pi
    return _dir2pi(option, argv)
  File "/opt/homebrew/lib/python3.8/site-packages/libpip2pi/commands.py", line 356, in _dir2pi
    pkg_name, pkg_rest = file_to_package(pkg_basename, pkgdir)
  File "/opt/homebrew/lib/python3.8/site-packages/libpip2pi/commands.py", line 159, in file_to_package
    raise InvalidFilePackageName(file, basedir)
libpip2pi.commands.InvalidFilePackageName: unexpected file name: 'index.html' (not in 'pkg-name-version.xxx' format; found in directory: '.')
user@host$
```

With this PR applied, I can exclude the non-package content:
```console
user@host$ dir2pi -X *.html .
user@host$
```

This may also resolve #68 and #69 in a more disciplined manner.