### PR TITLE
fixed bug: symbol link on windows is incorrect. invoke os.path.normpa…

### DIFF
--- a/libpip2pi/commands.py
+++ b/libpip2pi/commands.py
@@ -369,6 +369,7 @@ def _dir2pi(option, argv):
 
         symlink_target = os.path.join(pkg_dir, pkg_basename)
         symlink_source = os.path.join("../../", pkg_basename)
+        symlink_source = os.path.normpath(symlink_source)
         if option.use_symlink:
             try_symlink(option, symlink_source, symlink_target)
         else:


### PR DESCRIPTION
fix: symbol link "../../" on windows is incorrect. You should invoke os.path.normpath() to change "../../" to "..\\..\\" on windows
